### PR TITLE
Add create a post functionality.

### DIFF
--- a/ripple/src/main/webapp/postcommunity.html
+++ b/ripple/src/main/webapp/postcommunity.html
@@ -8,11 +8,24 @@
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script type='text/javascript' src='config.js'></script>   
+    <script type='text/javascript' src='config.js'></script>
+    <!-- Firebase configuration and initialization -->
+    <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase-auth.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase-firestore.js"></script>
+    <script>
+      firebase.initializeApp(config);
+      // Create auth and firestore references 
+      var auth = firebase.auth();
+      var db = firebase.firestore();
+    </script>
+    <!-- ./Firebase configuration and initialization -->
     <script src="script.js"></script>
+    <script src="auth.js"></script>
+    <script src="posts.js"></script>
     <title>Ripple</title>
   </head>
-  <body>
+  <body onload="postsOnload(); addDynamicPosts();">
     <!-- Banner -->
     <div class="half-bg-primary-color">
       <!--Navbar -->
@@ -51,109 +64,73 @@
         </div>
       </div>
       <!-- /.Navbar -->
-      <!-- Account settings header -->
-      <div class="container"> 
+      <!-- Post community header -->
+      <div class="container">
         <!-- <h1 class="left-align-header">Meet the faces</br>behind the business.</h1> -->
         <div class="header-subwrapper">
           <h1 class="header-title-text">Meet the faces</h1>
           <h1 class="header-title-text">behind the business.</h1>
         </div>
       </div>
-      <!-- /.Account settings header -->
+      <!-- /.Post community header -->
     </div>
     <!-- /.Banner -->
     <!-- Stories community content-->
-    <div class="post-container">
-      <!-- Post -->
-      <div class="post">
-        <div class="post-subwrapper space-between">
-          <div class="post-header">
-            <img id="post-avatar" src="images/undrawAvatar.svg" class="post-profile-photo">
-            <div class="post-user-business">
-              <p class="boldest-text">Ken Yang</p>
-              <p>Mandarette Cafe</p>
+    <!-- Container -->
+    <div class="container center">
+      <!-- Button to open the modal -->
+      <button type="button" id="post-button" data-toggle="modal" data-target="#myModal">
+        Share your story
+      </button>
+      <!-- The Modal -->
+      <div class="modal show fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <!-- Modal header -->
+            <div class="modal-header center">
+              <h3 class="col-12 modal-title center-align">
+                New post
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </h3>
             </div>
-          </div>
-          <img class="post-share-icon" src="/images/post_share_icon.png">
-        </div>
-        <img src="/images/family_restaurant.png" class="post-photo image-resizing">
-        <div class="post-line-height"> 
-          <div class="post-subwrapper">
-            <div class="space-between">
-              <p>
-                <span class="post-margin-right">
-                  <img class="heart-icon" src="/images/heart_icon.svg">
-                </span>
-                 482
-              </p>
-              <p>2 hours ago</p>
+            <!--/Modal  -->
+            <!-- Modal body -->
+            <div class="modal-body">
+              <div class="modal-subwrapper">
+                <div id="modal-upload-photo" class="modal-upload-photo" onclick="selectFile('post-file')">
+                  <div class="circle-icon">
+                    <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-images" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                      <path fill-rule="evenodd" d="M12.002 4h-10a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1zm-10-1a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-10z"/>
+                      <path d="M10.648 8.646a.5.5 0 0 1 .577-.093l1.777 1.947V14h-12v-1l2.646-2.354a.5.5 0 0 1 .63-.062l2.66 1.773 3.71-3.71z"/>
+                      <path fill-rule="evenodd" d="M4.502 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM4 2h10a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1v1a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2h1a1 1 0 0 1 1-1z"/>
+                    </svg>
+                  </div>
+                  <p>Add photo</p>
+                </div>
+                <form id="post-form" onchange="fetchBlobstoreUploadUrl('post-form', 'post-file', 'postcommunity.html')" method="post" enctype="multipart/form-data">
+                  <input id="post-file" type="file" name="post-file" style="display: none;">
+                </form>
+                <img onclick="selectFile('post-file')" id="modal-display-photo">
+                <div class="modal-caption">
+                  <textarea class="modal-caption-textarea" id="modal-caption" placeholder="Write a caption..."></textarea>
+                </div>
+                <!-- ./Modal body -->
+                <!-- Modal submit button -->
+                <div class="modal-centered-footer">
+                  <button disabled type="button" id="modal-share-button" class="modal-share-button" data-dismiss="modal">Share</button>
+                </div>
+                <!-- ./Modal submit button -->
+              </div>
             </div>
-            <p>
-              <span class="boldest-text">Ken Yang</span>
-              My team and I have had a difficult few months due to COVID, but we have adapted quickly to protect your safety and our own safety. 
-              We look forward to continuing to serve the food you love! 
-            </p>
-            <p class="post-view-all" onclick="viewAllPostComments()"> View all 153 comments</p>
-            <p>
-              <span class="boldest-text">Sarah Wu</span>
-              Love this photo!
-            </p>
-            <p>
-              <span class="boldest-text">Smruthi Balajee</span>
-              Wow, I'd really love to visit this place sometime!
-            </p>
-            <hr class="line-break-lighter">
-            <textarea class="post-comments" id="add-comment" placeholder="Commenting publicly..." 
-                onkeypress="addComment(event)"></textarea>
-          </div>
-        </div>
-      </div>
-      <!-- ./Post -->
-      <!-- Post -->
-      <div class="post">
-        <div class="post-subwrapper space-between">
-          <div class="post-header">
-            <img id="post-avatar" src="images/undrawAvatar.svg" class="post-profile-photo">
-            <div class="post-user-business">
-              <p class="boldest-text">Skel Islamaj</p>
-              <p>Maison Mathis</p>
-            </div>
-          </div>
-          <img class="post-share-icon" src="/images/post_share_icon.png">
-        </div>
-        <img src="/images/maison_mathis.jpg" class="post-photo image-resizing">
-        <div class="post-line-height"> 
-          <div class="post-subwrapper">
-            <div class="space-between">
-              <p>
-                <span class="post-margin-right">
-                  <img class="heart-icon" src="/images/unheart_icon.svg">
-                </span>
-                 482
-              </p>
-              <p>5 hours ago</p>
-            </div>
-            <p>
-              <span class="boldest-text">Skel Islamaj</span>
-              Omer and I created this cafe with the purpose of sharing a piece of European life with community. And we're still doing that today. Swing by for take-out! 
-            </p>
-            <p class="post-view-all" onclick="viewAllPostComments()">View all 201 comments</p>
-            <p>
-              <span class="boldest-text">Sarah Wu</span>
-              Hi Skel! Thanks for sharing. Can't wait to grab coffee to-go from your cafe soon!
-            </p>
-            <p>
-              <span class="boldest-text">Smruthi Balajee</span>
-              The Belgian bakery is definitely something that you have to partake in if you come here!
-            </p>
-            <hr class="line-break-lighter">
-            <textarea class="post-comments" id="add-comment" placeholder="Commenting publicly..." 
-                onkeypress="addComment(event)"></textarea>
           </div>
         </div>
       </div>
-      <!-- ./Post -->
+      <!-- ./Modal -->
     </div>
+    <!-- ./Container -->
+    <div id="post-container" class="post-container"></div>
     <!-- ./Stories community content-->
     </br></br></br></br></br></br></br></br></br></br>
   </body>

--- a/ripple/src/main/webapp/posts.js
+++ b/ripple/src/main/webapp/posts.js
@@ -6,12 +6,29 @@ function viewAllPostComments() {
 /* Display an alert if user presses enter to comment on a post */
 function addComment(e) {
   comment = document.getElementById("add-comment").value;
-  if (e.keyCode === 13) {
+  if (e.keyCode === ENTER_KEY) {
     alert("You are commenting: " + comment);
   }
 }
 
-// Add posts onto the Posts page TODO: ADD A LIMIT
+/* If blobKey found in URL, automatically open pop up and display image */
+function postsOnload() {
+  var blobKey = readBlobKeyFromURl();
+  if (blobKey != null) {
+    // Open pop up
+    clickElement("post-button");
+    // Hide upload form
+    hideElement("modal-upload-photo");
+    // Display photo
+    displayElement("modal-display-photo");
+    // Serve photo
+    serveBlob(blobKey, "modal-display-photo");
+    // Remove disabled attribute from share button
+    enableElement("modal-share-button");
+  }
+}
+
+// TODO: Reduce Firestore reads by using local storage.
 function addDynamicPosts() {
   var postContainerElement = document.getElementById("post-container");
   // For each document in this city, state, in reverse timestamp, create a post element & appendChild to postContainer
@@ -28,6 +45,7 @@ function addDynamicPosts() {
           var caption = doc.data().caption;
           var numberComments = doc.data().numberComments;
           var blobKey = doc.data().blobKey;
+          console.log("blobKey: " + blobKey);
           // make sure that the postContainerElement finishes before the promises return
           getNameFromFirestoreFuture('businesses', uid, function(querySnapshot) {
             querySnapshot.forEach(function(doc) {
@@ -62,8 +80,6 @@ function getNameFromFirestoreFuture(collection, uid, lambda) {
           console.log("Error getting documents: ", error);
       });
 }
-
-
 
 // Create a post element
 function createPostElement(userName, businessName, caption, numberComments, blobKey) {

--- a/ripple/src/main/webapp/script.js
+++ b/ripple/src/main/webapp/script.js
@@ -6,7 +6,9 @@ function serveBlob(blobKey, imageId) {
   image.src = '/serve?blob-key=' + blobKey;
 }
 
+/* Define global variable for enter key */
 var ENTER_KEY = 13;
+
 /* Display an alert if user presses enter to comment on a post */
 function addComment(e) {
   comment = document.getElementById("add-comment").value;
@@ -28,7 +30,7 @@ function fetchBlobstoreUploadUrl(formId, fileId, webUrl) {
     console.log("fetched blobstoreUploadUrl: " + blobstoreUploadUrl);
     form.submit();
   });
-}
+} 
 
 /* Serves blob by parsing blobKey from parameter. If no parameter, serves stored blob. */
 function getBlobKey(uid, blobKey) {
@@ -54,6 +56,12 @@ function getBlobKey(uid, blobKey) {
     serveBlob(blobKey, "nav-bar-avatar");
     serveBlob(blobKey, "profile-image");
   }
+}
+
+function readBlobKeyFromURl() {
+  var blobKey = getParameterByName('blob-key');
+  console.log("Parameter blobKey: " + blobKey);
+  return blobKey;
 }
 
 /* Read parameter in URL of window */
@@ -94,3 +102,17 @@ function selectFile(fileId) {
   document.getElementById(fileId).click();
 }
 
+/* Clicks button given id */
+function clickElement(id) {
+  document.getElementById(id).click();
+}
+
+/* Hides element given an id */
+function hideElement(id) {
+  document.getElementById(id).style.display = "none";
+}
+
+/* Removes disabled attribute from element given an id */
+function enableElement(id) {
+  document.getElementById(id).disabled = false;
+}

--- a/ripple/src/main/webapp/script.js
+++ b/ripple/src/main/webapp/script.js
@@ -30,30 +30,6 @@ function fetchBlobstoreUploadUrl(formId, fileId, webUrl) {
   });
 } 
 
-/* Serves blob by parsing blobKey from parameter. If no parameter, serves stored blob. */
-function getBlobKey(uid, blobKey) {
-  var newBlobKey = getParameterByName('blob-key');
-  console.log("Parameter blobKey: " + newBlobKey);
-  // New image uploaded. Store blobkey in firestore.
-  if (newBlobKey != null) {
-    console.log("New image. Blobkey parameter: ", newBlobKey);
-    db.collection("users").doc(uid).update({
-      blobKey: newBlobKey,
-    }).then(function() {
-    console.log("Document successfully updated!");
-    }).catch(function(error) {
-        // The document probably doesn't exist.
-        console.error("Error updating document: ", error);
-    });
-    serveBlob(newBlobKey, "nav-bar-avatar");
-    serveBlob(newBlobKey, "profile-image");
-  } else {
-    console.log("firestore blobKey: " + blobKey);
-    serveBlob(blobKey, "nav-bar-avatar");
-    serveBlob(blobKey, "profile-image");
-  }
-}
-
 function readBlobKeyFromURl() {
   var blobKey = getParameterByName('blob-key');
   console.log("Parameter blobKey: " + blobKey);

--- a/ripple/src/main/webapp/script.js
+++ b/ripple/src/main/webapp/script.js
@@ -20,11 +20,9 @@ function addComment(e) {
 /* creates blobstoreUrl for image to firestore */
 function fetchBlobstoreUploadUrl(formId, fileId, webUrl) {
   console.log("called fetchBlobstoreUploadUrl(" + formId + ", " + fileId + ", " + webUrl + ")");
-  fetch('/blobstore-upload-url?file-id=' + fileId + '&web-url=' + webUrl)
-  .then((response) => {
+  fetch('/blobstore-upload-url?file-id=' + fileId + '&web-url=' + webUrl).then((response) => {
     return response.text();
-  })
-  .then((blobstoreUploadUrl) => {
+  }).then((blobstoreUploadUrl) => {
     const form = document.getElementById(formId);
     form.action = blobstoreUploadUrl;
     console.log("fetched blobstoreUploadUrl: " + blobstoreUploadUrl);
@@ -41,11 +39,9 @@ function getBlobKey(uid, blobKey) {
     console.log("New image. Blobkey parameter: ", newBlobKey);
     db.collection("users").doc(uid).update({
       blobKey: newBlobKey,
-    })
-    .then(function() {
+    }).then(function() {
     console.log("Document successfully updated!");
-    })
-    .catch(function(error) {
+    }).catch(function(error) {
         // The document probably doesn't exist.
         console.error("Error updating document: ", error);
     });

--- a/ripple/src/main/webapp/style.css
+++ b/ripple/src/main/webapp/style.css
@@ -644,8 +644,11 @@
   height: 70px;
 }
 
-.modal-display-photo {
+#modal-display-photo {
+  cursor: pointer;
+  display: none;
   height: 491px;
+  object-fit: cover;
   width: 100%;
 }
 


### PR DESCRIPTION
**Description**: Business owners can create post directly on the Posts page by clicking the button 'Share your story.' A pop up form is presented that allows business owner to select a photo from their local files, write a caption, and post to the page.

**Key features**:
  - **Upload form**: When the user uploads a new photo, the blob is stored in Blobstore, and the page is redirected with the blob key included in the parameter.
  - **Photo preview before posting**: Blob key is read from parameter and served to present the user a preview of the image.
  - **Caption textarea**: User can type a caption to be stored later.
  - **Share button**: If the user has not yet uploaded a photo, this button is disabled. Once the user uploads an image, the button is enabled. 

**Demo**:
Business owner clicks 'Share your story' to generate pop up. User types in a caption and attempts to share post, but button is disabled. User uploads one photo, then replaces the photo and shares the post.
![Create a post functionality](https://user-images.githubusercontent.com/39513112/88236342-998f7180-cc31-11ea-91dc-19da48ee58db.gif)
See full video: https://drive.google.com/file/d/11mi3msBGakr8_tCJ8yDFWVvt30NEqqbZ/view

**Future steps**:
  - Save caption to local storage if user clicks away from post or uploads a new photo. 
  - Write blob key, caption, user name, business name, timestamp to Firestore. 