### PR TITLE
Connects business cards to business details page, dynamically populates "Under 20 mins away" carousel

### DIFF
--- a/ripple/src/main/webapp/businesscarousels.js
+++ b/ripple/src/main/webapp/businesscarousels.js
@@ -48,7 +48,6 @@ function getAddressComponent(components, type) {
   return components.filter((component) => component.types.indexOf(type) === 0).map((item) => item.long_name).pop() || null;
 }
 
-
 /* Carousel function that allows cards to move to the left or right by one. Establishes functionality of the carousel. */
 function cardFunctionality() {
   $("#card-carousel1").on("slide.bs.carousel", function(e) {
@@ -117,12 +116,11 @@ function addDynamicCarouselByTag(carouselId, tag) {
               
               // Call distance matrix service
               var service = new google.maps.DistanceMatrixService();
-              service.getDistanceMatrix(
-                {
-                  origins: [origin],
-                  destinations: [destination],
-                  travelMode: google.maps.TravelMode.WALKING,
-                }, callback);
+              service.getDistanceMatrix({
+                origins: [origin],
+                destinations: [destination],
+                travelMode: google.maps.TravelMode.WALKING,
+              }, callback);
               
               // In callback function, dynamically construct the HTML for the cards in each carousel
               function callback(response, status) {
@@ -194,12 +192,11 @@ function addDynamicCarouselByTime(carouselId, time) {
               
               // Call distance matrix service
               var service = new google.maps.DistanceMatrixService();
-              service.getDistanceMatrix(
-                {
-                  origins: [origin],
-                  destinations: [destination],
-                  travelMode: google.maps.TravelMode.WALKING,
-                }, callback);
+              service.getDistanceMatrix({
+                origins: [origin],
+                destinations: [destination],
+                travelMode: google.maps.TravelMode.WALKING,
+              }, callback);
               
               // In callback function, dynamically construct the HTML for the cards in each carousel
               function callback(response, status) {

--- a/ripple/src/main/webapp/businesscarousels.js
+++ b/ripple/src/main/webapp/businesscarousels.js
@@ -76,10 +76,13 @@ function cardFunctionality() {
   });
 }
 
+// Defines the max walking time allowed in the nearby business carousel.
+var maxWalkingTime = 1200;
+
 /* Code to dynamically load carousels. Calls addDynamicCarousel function to populate the carousels. */
 function loadCarousels() {
     addDynamicCarouselByTag("black-owned-businesses", "Black-owned");
-    addDynamicCarouselByTime("under-20-mins-away", 1200);
+    addDynamicCarouselByTime("under-20-mins-away", maxWalkingTime);
     addDynamicCarouselByTag("trending-near-you", "Trending");
     addDynamicCarouselByTag("up-and-coming", "New");
 }

--- a/ripple/src/main/webapp/businessgallery.js
+++ b/ripple/src/main/webapp/businessgallery.js
@@ -24,7 +24,6 @@ function loadSearchResults() {
     }
 }
 
-
 /* Function that dynamically loads the businesses into the gallery, depending on the tag that was searched/selected. 
    Filters by the business tags.*/
 function loadSearchResultsTags(tag) {

--- a/ripple/src/main/webapp/businessgallery.js
+++ b/ripple/src/main/webapp/businessgallery.js
@@ -54,12 +54,11 @@ function loadSearchResultsTags(tag) {
               
               // Call distance matrix service
               var service = new google.maps.DistanceMatrixService();
-              service.getDistanceMatrix(
-                {
-                  origins: [origin],
-                  destinations: [destination],
-                  travelMode: google.maps.TravelMode.WALKING,
-                }, callback);
+              service.getDistanceMatrix({
+                origins: [origin],
+                destinations: [destination],
+                travelMode: google.maps.TravelMode.WALKING,
+              }, callback);
               
               // In callback function, dynamically construct the HTML for the cards in each carousel
               function callback(response, status) {
@@ -124,12 +123,11 @@ function loadSearchResultsTime(time) {
               
               // Call distance matrix service
               var service = new google.maps.DistanceMatrixService();
-              service.getDistanceMatrix(
-                {
-                  origins: [origin],
-                  destinations: [destination],
-                  travelMode: google.maps.TravelMode.WALKING,
-                }, callback);
+              service.getDistanceMatrix({
+                origins: [origin],
+                destinations: [destination],
+                travelMode: google.maps.TravelMode.WALKING,
+              }, callback);
               
               // In callback function, dynamically construct the HTML for the cards in each carousel
               function callback(response, status) {

--- a/ripple/src/main/webapp/businessgallery.js
+++ b/ripple/src/main/webapp/businessgallery.js
@@ -15,14 +15,24 @@ function displayName() {
   document.getElementById("left-align-header").innerHTML = localStorage.getItem("galleryPageName");
 }
 
-/* Function that dynamically loads the businesses into the gallery, depending on the tag that was searched/selected. */
 function loadSearchResults() {
+    var tag = localStorage.getItem('galleryPageSearchTag');
+    if (tag == 'Close') {
+        loadSearchResultsTime(maxWalkingTime);
+    } else {
+        loadSearchResultsTags(tag);
+    }
+}
+
+
+/* Function that dynamically loads the businesses into the gallery, depending on the tag that was searched/selected. 
+   Filters by the business tags.*/
+function loadSearchResultsTags(tag) {
     db.collection("businesses").get().then((querySnapshot) => {
         var makeElement = false;
         querySnapshot.forEach((doc) => {
             //Check if the city in Firestore matches the city extracted from the user inputted address.
             //Also checks if the business's tag list contains the tag that the carousel requires.
-            var tag = localStorage.getItem('galleryPageSearchTag');
             if (doc.data().address != null && doc.data().address[1] == localStorage.getItem('enteredCity') 
                 && doc.data().tags[convertToRawString(tag)] !== undefined) {
               makeElement = true;
@@ -58,6 +68,9 @@ function loadSearchResults() {
                     return;
                 }
                 // Construct card content by appending HTML strings
+                var walkingTime = response.rows[0].elements[0].duration.text;
+                var walkingDist = response.rows[0].elements[0].distance.text;
+                
                 var content = `
                 <div class="col-6 col-md-4 col-lg-3 mb-4">
                     <div class="card h-100">
@@ -73,6 +86,76 @@ function loadSearchResults() {
 
                 // Append newly created card element to the container
                 if (makeElement) {
+                  var galleryElement = document.getElementById("row");
+                  galleryElement.innerHTML = galleryElement.innerHTML + content + "\n";
+                }
+              }
+            }
+        });
+   });
+}
+
+/* Function that dynamically loads the businesses into the gallery, depending on the tag that was searched/selected. 
+   Filters by the walking time in seconds.*/
+function loadSearchResultsTime(time) {
+    db.collection("businesses").get().then((querySnapshot) => {
+        var makeElement = false;
+        querySnapshot.forEach((doc) => {
+            //Check if the city in Firestore matches the city extracted from the user inputted address.
+            //Also checks if the business's tag list contains the tag that the carousel requires.
+            var tag = localStorage.getItem('galleryPageSearchTag');
+            if (doc.data().address != null && doc.data().address[1] == localStorage.getItem('enteredCity')) {
+              makeElement = true;
+              const card = document.createElement('div');
+              card.classList = 'row';
+
+               // Distance matrix calculations
+              // Get user's latitude and longitude from localStorage
+              var userLat = localStorage.getItem('enteredLat');
+              var userLong = localStorage.getItem('enteredLong');
+
+              // Get business latitude and longitude from GeoPoint object in firestore
+              var busLat = doc.data().coordinates.latitude;
+              var busLong = doc.data().coordinates.longitude;
+
+              // Reconstruct as maps LatLng object
+              var origin = new google.maps.LatLng(userLat, userLong);
+              var destination = new google.maps.LatLng(busLat, busLong);
+              
+              // Call distance matrix service
+              var service = new google.maps.DistanceMatrixService();
+              service.getDistanceMatrix(
+                {
+                  origins: [origin],
+                  destinations: [destination],
+                  travelMode: google.maps.TravelMode.WALKING,
+                }, callback);
+              
+              // In callback function, dynamically construct the HTML for the cards in each carousel
+              function callback(response, status) {
+                if (status !== "OK") {
+                    alert("Error with distance matrix");
+                    return;
+                }
+                 // Construct card content by appending HTML strings
+                var walkingTime = response.rows[0].elements[0].duration.text;
+                var walkingDist = response.rows[0].elements[0].distance.text;
+
+                var content = `
+                <div class="col-6 col-md-4 col-lg-3 mb-4">
+                    <div class="card h-100">
+                    <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${doc.data().thumbnailImage}"
+                                onclick="redirectToBusinessInfo('${doc.id}', '${walkingDist}', '${walkingTime}')"></img>
+                        <div class="card-body">
+                            <p class="card-text">${doc.data().businessName[1]}</p>
+                            <p class="card-text"><small class="text-muted">${response.rows[0].elements[0].duration.text + " walking"}</small></p>
+                        </div>
+                    </div>
+                </div>
+               `;
+
+                // Append newly created card element to the container only if the walking duration is less than the inputted time
+                if (makeElement && response.rows[0].elements[0].duration.value <= time) {
                   var galleryElement = document.getElementById("row");
                   galleryElement.innerHTML = galleryElement.innerHTML + content + "\n";
                 }

--- a/ripple/src/main/webapp/businessgallery.js
+++ b/ripple/src/main/webapp/businessgallery.js
@@ -61,7 +61,8 @@ function loadSearchResults() {
                 var content = `
                 <div class="col-6 col-md-4 col-lg-3 mb-4">
                     <div class="card h-100">
-                    <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${doc.data().thumbnailImage}">
+                    <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${doc.data().thumbnailImage}"
+                                onclick="redirectToBusinessInfo('${doc.id}', '${walkingDist}', '${walkingTime}')"></img>
                         <div class="card-body">
                             <p class="card-text">${doc.data().businessName[1]}</p>
                             <p class="card-text"><small class="text-muted">${response.rows[0].elements[0].duration.text + " walking"}</small></p>

--- a/ripple/src/main/webapp/businessgallery.js
+++ b/ripple/src/main/webapp/businessgallery.js
@@ -1,3 +1,13 @@
+/* Dynamically populates the view all and search result pages. */
+
+/* Maps JS API initialization */
+var mapKey = config.apiKey;
+var script = document.createElement("script");
+script.src = "https://maps.googleapis.com/maps/api/js?key=" + mapKey + "&region=US&libraries=places";
+script.defer = true;
+script.async = true;
+document.head.appendChild(script);
+
 /* Function to dynamically load the name of the gallery page. Will either be the user's search input or view all. */
 function displayName() {
   console.log(localStorage.getItem("galleryPageName"));
@@ -8,7 +18,6 @@ function displayName() {
 /* Function that dynamically loads the businesses into the gallery, depending on the tag that was searched/selected. */
 function loadSearchResults() {
     db.collection("businesses").get().then((querySnapshot) => {
-        var contentStrings = [];
         var makeElement = false;
         querySnapshot.forEach((doc) => {
             //Check if the city in Firestore matches the city extracted from the user inputted address.
@@ -20,26 +29,54 @@ function loadSearchResults() {
               const card = document.createElement('div');
               card.classList = 'row';
 
-            // Construct card content by appending HTML strings
-              var content = `
+               // Distance matrix calculations
+              // Get user's latitude and longitude from localStorage
+              var userLat = localStorage.getItem('enteredLat');
+              var userLong = localStorage.getItem('enteredLong');
+
+              // Get business latitude and longitude from GeoPoint object in firestore
+              var busLat = doc.data().coordinates.latitude;
+              var busLong = doc.data().coordinates.longitude;
+
+              // Reconstruct as maps LatLng object
+              var origin = new google.maps.LatLng(userLat, userLong);
+              var destination = new google.maps.LatLng(busLat, busLong);
+              
+              // Call distance matrix service
+              var service = new google.maps.DistanceMatrixService();
+              service.getDistanceMatrix(
+                {
+                  origins: [origin],
+                  destinations: [destination],
+                  travelMode: google.maps.TravelMode.WALKING,
+                }, callback);
+              
+              // In callback function, dynamically construct the HTML for the cards in each carousel
+              function callback(response, status) {
+                if (status !== "OK") {
+                    alert("Error with distance matrix");
+                    return;
+                }
+                // Construct card content by appending HTML strings
+                var content = `
                 <div class="col-6 col-md-4 col-lg-3 mb-4">
                     <div class="card h-100">
                     <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${doc.data().thumbnailImage}">
                         <div class="card-body">
                             <p class="card-text">${doc.data().businessName[1]}</p>
-                            <p class="card-text"><small class="text-muted">${doc.data().walkingDistance}</small></p>
+                            <p class="card-text"><small class="text-muted">${response.rows[0].elements[0].duration.text + " walking"}</small></p>
                         </div>
                     </div>
                 </div>
-              `;
-              //Add every line of reconstructed HTML to contentStrings array
-              contentStrings.push(content);
+               `;
+
+                // Append newly created card element to the container
+                if (makeElement) {
+                  var galleryElement = document.getElementById("row");
+                  galleryElement.innerHTML = galleryElement.innerHTML + content + "\n";
+                }
+              }
             }
         });
-        // Append newly created card element to the container
-        if (makeElement) {
-          var galleryElement = document.getElementById("row");
-          galleryElement.innerHTML = contentStrings.join("\n");
-        }
    });
 }

--- a/ripple/src/main/webapp/index.html
+++ b/ripple/src/main/webapp/index.html
@@ -17,7 +17,6 @@
       firebase.initializeApp(config);
     </script>
     <!-- ./Firebase configuration and initialization -->
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBo4gWG5T9oBscp7tHWzSL9L4masICev5U&region=US&libraries=places"></script>
     <script src="script.js"></script>
     <script src="auth.js"></script>
     <script src="landing.js"></script>

--- a/ripple/src/main/webapp/landing.js
+++ b/ripple/src/main/webapp/landing.js
@@ -1,5 +1,14 @@
 /* Address input and autocomplete functions. */
 
+/* Maps JS API initialization */
+var mapKey = config.apiKey;
+var script = document.createElement("script");
+script.src = "https://maps.googleapis.com/maps/api/js?key=" + mapKey + "&region=US&libraries=places";
+script.defer = true;
+script.async = true;
+document.head.appendChild(script); 
+
+
 /* Function that utilizes the Place API to implement an autocomplete feature when a user is entering an address. */
 function searchAddressAutocomplete() {
     var input = document.getElementById('address-input');

--- a/ripple/src/main/webapp/landingbusiness.html
+++ b/ripple/src/main/webapp/landingbusiness.html
@@ -23,7 +23,6 @@
     <script src="auth.js"></script>
     <script src="firestore.js"></script>
     <!-- ./Firebase configuration and initialization -->
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBo4gWG5T9oBscp7tHWzSL9L4masICev5U"></script>
     <script src="script.js"></script>
     <script src="landing.js"></script>
     <title>Ripple</title>

--- a/ripple/src/main/webapp/main.html
+++ b/ripple/src/main/webapp/main.html
@@ -26,7 +26,6 @@
       var db = firebase.firestore();
     </script>
     <!-- ./Firebase configuration and initialization -->
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBo4gWG5T9oBscp7tHWzSL9L4masICev5U&region=US&libraries=places"></script>
     <script src="trie.js"></script>
     <script src="script.js"></script>
     <script src="auth.js"></script>
@@ -77,7 +76,7 @@
             <p class="cluster-title">Black-owned businesses</p>
             <p class="cluster-subtitle"><small class="text-muted">Let's support our neighbors.</small></p>
             <div class="cluster-title-button">
-              <button class="view-all" onclick="viewAll('Black-owned')">View all ></button>
+              <button class="text-only" onclick="viewAll('Black-owned')">View all ></button>
             </div>
           </div>
           <div id="black-owned-businesses" class="carousel slide" data-interval="false">
@@ -91,20 +90,20 @@
               <span class="sr-only">Next</span>
             </a>
           </div>
-            <div class="cluster-title-container">
-            <p class="cluster-title">Under 10 minutes away</p>
+          <div class="cluster-title-container">
+            <p class="cluster-title">Under 20 minutes away</p>
             <p class="cluster-subtitle"><small class="text-muted">Faster is always better.</small></p>
             <div class="cluster-title-button">
-              <button class="view-all" onclick="viewAll('Close')">View all ></button>
-            </div>
+              <button class="text-only" onclick="viewAll('Close')">View all ></button>
           </div>
-          <div id="under-10-mins-away" class="carousel slide" data-interval="false">
+          </div>
+          <div id="under-20-mins-away" class="carousel slide" data-interval="false">
             <div class="carousel-inner row w-100 mx-auto"></div>
-            <a class="carousel-control-prev" href="#under-10-mins-away" role="button" data-slide="prev">
+            <a class="carousel-control-prev" href="#under-20-mins-away" role="button" data-slide="prev">
               <span class="carousel-control-prev-icon" aria-hidden="true"></span>
               <span class="sr-only">Previous</span>
             </a>
-            <a class="carousel-control-next" href="#under-10-mins-away" role="button" data-slide="next">
+            <a class="carousel-control-next" href="#under-20-mins-away" role="button" data-slide="next">
               <span class="carousel-control-next-icon" aria-hidden="true"></span>
               <span class="sr-only">Next</span>
             </a>
@@ -113,7 +112,7 @@
             <p class="cluster-title">Trending near you</p>
             <p class="cluster-subtitle"><small class="text-muted">The best of your city, one click away.</small></p>
             <div class="cluster-title-button">
-              <button class="view-all" onclick="viewAll('Trending')">View all ></button>
+              <button class="text-only" onclick="viewAll('Trending')">View all ></button>
             </div>
           </div>
           <div id="trending-near-you" class="carousel slide" data-interval="false">
@@ -131,7 +130,7 @@
             <p class="cluster-title">Up-and-coming</p>
             <p class="cluster-subtitle"><small class="text-muted">Explore something new--you might find a favorite.</small></p>
             <div class="cluster-title-button">
-              <button class="view-all" onclick="viewAll('New')">View all ></button>
+              <button class="text-only" onclick="viewAll('New')">View all ></button>
             </div>
           </div>
           <div id="up-and-coming" class="carousel slide" data-interval="false">
@@ -148,6 +147,5 @@
           <!-- /.Card Carousels -->
       </div>
     </div>
-    <div id="card-container"></div>
   </body>
 </html>


### PR DESCRIPTION
**Description:** Wrote function to redirect users from the business cards in the carousels/galleries to the business details page when clicked. Currently the business details page is hard-coded, so the function stores the walking distance (from user's location to business address), walking time, and businessId in local storage to be used later when dynamically populating the business details page. Additionally, the "Under 20 mins away" carousel is no longer hard-coded with the "Close" tag. It now checks whether the walking time calculated for a specific business is lower than the max time allowed (20 minutes) before adding the business to the carousel. Deleted the "Close" tag from all the businesses currently in Firestore.

**Key Features:**
- **Image onclick function with dynamically-loaded parameters**
    - Added an onclick function to the image tag in the content string which reconstructs the card HTML when querying businesses. The function takes in parameters that are only accessible within the firestore business query, like the walking time/distance and the business id. This ensures that the businessdetails page can access the relevant business id in order to dynamically load data for the business the user clicked on. When the image is clicked, users are redirected to the businessdetails.js file.

- **Query function that takes in max walking time instead of tags**
    - Created a new query function that takes in a max walking time in seconds. Instead of checking whether the tags in the business match, this compares the calculated walking time from the Distance Matrix API with the time parameter. If the walking time is less than or equal to the max time passed in, the card is constructed and displayed in the carousel.

- **View all for walking time-based carousel**
    - Ran into some complications with the view all buttons once the hard-coded "Close" tag was removed from firestore. View all takes in a tag as a parameter to indicate which carousel it was clicked from. To avoid changing this fundamental structure, used the 'Close' tag passed in by the view all function as a check. If the tag equals "Close", then the function that queries based on walking distance will be called. Otherwise, the normal tag-based query function will be called to populate the gallery. Another nice feature is that if a user just searches close, it will automatically return the nearby businesses rather than looking for the word close in a business name.

**Demo of "Under 20 mins away" view all page functioning**
![time-view-all](https://user-images.githubusercontent.com/20546276/89032152-e38aee00-d2e8-11ea-919a-b384ab3568ca.gif)


**Demo of redirect** [ignore the css for business details--the updated files are not merged with mine yet]
![redirect](https://user-images.githubusercontent.com/20546276/89032304-3c5a8680-d2e9-11ea-9989-9b61f655ca11.gif)

